### PR TITLE
Fixing fib type bug

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,12 +1,15 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
-  } else if (n == 0) {
+  } else if (n === 0) {
     return 0;
-  } else if (n == 1) {
+  } else if (n === 1) {
     return 1;
   }
+  
+  const a: number = fibonacci(n - 1);
+  const b: number = fibonacci(n - 2);
 
-  return fibonacci(n - 1) + fibonacci(n - 2);
+  return a + b;
 }


### PR DESCRIPTION
Changed the parameter n to include number and == to === to ensure valid checking. This is to reduce uncertainty of the any type showing up.